### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/PSGI.pm6
+++ b/lib/PSGI.pm6
@@ -1,5 +1,5 @@
 ## Some helpers for PSGI frameworks.
-module PSGI;
+unit module PSGI;
 
 use HTTP::Status;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.