### PR TITLE
Allow output to be a Buf

### DIFF
--- a/lib/PSGI.pm6
+++ b/lib/PSGI.pm6
@@ -15,7 +15,7 @@ multi sub encode-psgi-response (
   Int(Any) $code, $headers, $body,             ## Required parameters.
   Bool :$nph, :$protocol=DEFAULT_PROTOCOL      ## Optional parameters.
 ) is export {
-  my Str $output;
+  my Stringy $output;
   my $message = get_http_status_msg($code);
   if $nph {
     $output = "$protocol $code $message" ~ CRLF;

--- a/t/encode-psgi-response.t
+++ b/t/encode-psgi-response.t
@@ -7,13 +7,14 @@ use lib 'lib';
 use Test;
 use PSGI;
 
-plan 24;
+plan 30;
 
 my $status    = 200;
 my @headers   = 'Content-Type'=>'text/plain';
 my %headers   = 'Content-Type'=>'text/plain';
 my $body      = "Hello world";
 my @body      = $body;
+my $buf-body  = $body.encode;
 
 sub test_response ($name, $status, $headers, $body, $wanted, *%opts) {
   my $string = encode-psgi-response($status, $headers, $body, |%opts);
@@ -43,11 +44,13 @@ my $nph2  = "HTTP+TEST/2.2 200 OK$CRLF";
 test_response('defaults',     $status, @headers, @body, $cgi);
 test_response('hash headers', $status, %headers, @body, $cgi);
 test_response('str body',     $status, @headers, $body, $cgi);
+test_response('buf body',     $status, @headers, $buf-body, $cgi);
 test_response('hash & str',   $status, %headers, $body, $cgi);
 
 test_response('NPH defaults',     $status, @headers, @body, $nph, :nph);
 test_response('NPH hash headers', $status, %headers, @body, $nph, :nph);
 test_response('NPH str body',     $status, @headers, $body, $nph, :nph);
+test_response('NPH buf body',     $status, @headers, $buf-body, $nph, :nph);
 test_response('NPH hash & str',   $status, %headers, $body, $nph, :nph);
 
 my $protocol = 'HTTP+TEST/2.2';
@@ -58,5 +61,7 @@ test_response('custom NPH hash headers',
   $status, %headers, @body, $nph2, :nph, :$protocol);
 test_response('custom NPH str body',     
   $status, @headers, $body, $nph2, :nph, :$protocol);
+test_response('custom NPH buf body',     
+  $status, @headers, $buf-body, $nph2, :nph, :$protocol);
 test_response('custom NPH hash & str',   
   $status, %headers, $body, $nph2, :nph, :$protocol);


### PR DESCRIPTION
As mentioned in https://github.com/supernovus/perl6-psgi/issues/6, forcing output to be a `Str` prevents sending binary (encoding as a string gets "invalid utf-8" errors, trying to pass a Buf fails the type check when assigning to $output.)

Since `Buf ~~ Stringy` and `Str ~~ Stringy`, just changing the type allows both to work.